### PR TITLE
Add the AmazonSSMManagedInstanceCore policy to the instance role for the SSM agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+* @dav3r @jsf9k

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-tf-module.git

--- a/iam.tf
+++ b/iam.tf
@@ -32,6 +32,14 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment_ne
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
+# Attach the SSM Agent policy to this role as well
+resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment_nessus" {
+  count = var.create_nessus_instance ? 1 : 0
+
+  role       = aws_iam_role.nessus_instance_role[count.index].id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 ################################
 # Define the role policies below
 ################################

--- a/security_group.tf
+++ b/security_group.tf
@@ -15,19 +15,6 @@ resource "aws_security_group" "nessus" {
   )
 }
 
-# Allow ingress from OpenVPN server subnet via SSH
-# For: DevOps team SSH access from within the COOL
-resource "aws_security_group_rule" "nessus_ingress_from_vpn_users_via_ssh" {
-  count = var.create_nessus_instance ? 1 : 0
-
-  cidr_blocks       = [local.vpn_server_cidr_block]
-  protocol          = "tcp"
-  security_group_id = aws_security_group.nessus[count.index].id
-  type              = "ingress"
-  from_port         = 22
-  to_port           = 22
-}
-
 # Allow ingress from OpenVPN server subnet via Nessus web GUI
 # For: DevOps team Nessus web GUI access from within the COOL
 resource "aws_security_group_rule" "nessus_ingress_from_vpn_users" {


### PR DESCRIPTION
## 🗣 Description

This pull request adds the AWS-provided `AmazonSSMManagedInstanceCore` policy to the Nessus server instance role for the SSM agent.

We recently made similar changes for the FreeIPA and OpenVPN instances:

- https://github.com/cisagov/freeipa-server-tf-module/pull/23
- https://github.com/cisagov/freeipa-replica-tf-module/pull/14
- https://github.com/cisagov/openvpn-server-tf-module/pull/29


## 💭 Motivation and Context

With [aws/amazon-ssm-agent](https://github.com/aws/amazon-ssm-agent) we can get a shell on any instance (with or without `ssh`) via the AWS control plane.  This means we do not need to open port 22 or even provide a public IP or Internet Gateway.

## 🧪 Testing

All the pre-commit hooks pass.  Also, I verified that I was able to SSH to the Nessus instance in Shared Services (Production) after I applied these changes (and rebooted the Nessus instance).

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
