### PR TITLE
Stop using deprecated provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ have been applied.
 |------|---------|
 | terraform | ~> 0.12.0 |
 | aws | ~> 3.0 |
-| template | ~> 2.1 |
+| cloudinit | ~> 2.0 |
 
 ## Providers ##
 
@@ -26,7 +26,7 @@ have been applied.
 | aws | ~> 3.0 |
 | aws.organizationsreadonly | ~> 3.0 |
 | aws.provisionparameterstorereadrole | ~> 3.0 |
-| template | ~> 2.1 |
+| cloudinit | ~> 2.0 |
 | terraform | n/a |
 
 ## Inputs ##
@@ -44,7 +44,7 @@ have been applied.
 
 | Name | Description |
 |------|-------------|
-| instance_id | The Nessus instance ID |
+| instance_id | The Nessus EC2 instance ID |
 | security_group_id | The ID corresponding to the Nessus security group |
 
 ## Notes ##

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -1,6 +1,6 @@
 # cloud-init commands for configuring Nessus instances
 
-data "template_cloudinit_config" "nessus_cloud_init_tasks" {
+data "cloudinit_config" "nessus_cloud_init_tasks" {
   count = var.create_nessus_instance ? 1 : 0
 
   gzip          = true

--- a/ec2.tf
+++ b/ec2.tf
@@ -43,7 +43,7 @@ resource "aws_instance" "nessus" {
     delete_on_termination = true
   }
 
-  user_data_base64 = data.template_cloudinit_config.nessus_cloud_init_tasks[count.index].rendered
+  user_data_base64 = data.cloudinit_config.nessus_cloud_init_tasks[count.index].rendered
 
   vpc_security_group_ids = [
     aws_security_group.nessus[count.index].id

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws      = "~> 3.0"
-    template = "~> 2.1"
+    aws       = "~> 3.0"
+    cloudinit = "~> 2.0"
   }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request gets rid of the deprecated [template Terraform provider](https://registry.terraform.io/providers/hashicorp/template/latest/docs) in favor of the [cloudinit Terraform provider](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs).

## 💭 Motivation and Context

The deprecated template provider could disappear altogether at any time.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Halt the ever-advancing threat of obsolescence

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
