### PR TITLE
Upgrade the root volume type to gp3

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -38,8 +38,8 @@ resource "aws_instance" "nessus" {
   subnet_id                   = local.nessus_subnet.id
 
   root_block_device {
-    volume_type = "gp3"
     volume_size = 128
+    volume_type = "gp3"
   }
 
   user_data_base64 = data.cloudinit_config.nessus_cloud_init_tasks[count.index].rendered

--- a/ec2.tf
+++ b/ec2.tf
@@ -38,7 +38,7 @@ resource "aws_instance" "nessus" {
   subnet_id                   = local.nessus_subnet.id
 
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = 128
     delete_on_termination = true
   }

--- a/ec2.tf
+++ b/ec2.tf
@@ -38,9 +38,8 @@ resource "aws_instance" "nessus" {
   subnet_id                   = local.nessus_subnet.id
 
   root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 128
-    delete_on_termination = true
+    volume_type = "gp3"
+    volume_size = 128
   }
 
   user_data_base64 = data.cloudinit_config.nessus_cloud_init_tasks[count.index].rendered


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the root volume type from gp2 to gp3.

## 💭 Motivation and context ##

gp3 is 20% cheaper, and the baseline configuration offers better performance than gp2 for volumes smaller than 2TB.  It also allows the volume size and IOPS to be configured separately, whereas the two are codependent with gp2.

## 🧪 Testing ##

See cisagov/cool-assessment-terraform#148 for an example of how I tested identical changes in another repository.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
