### PR TITLE
Add some security groups to the Nessus instance

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -45,7 +45,11 @@ resource "aws_instance" "nessus" {
   user_data_base64 = data.cloudinit_config.nessus_cloud_init_tasks[count.index].rendered
 
   vpc_security_group_ids = [
-    aws_security_group.nessus[count.index].id
+    aws_security_group.nessus[count.index].id,
+    data.terraform_remote_state.networking.outputs.cloudwatch_agent_endpoint_client_security_group.id,
+    data.terraform_remote_state.networking.outputs.ssm_agent_endpoint_client_security_group.id,
+    data.terraform_remote_state.networking.outputs.ssm_endpoint_client_security_group.id,
+    data.terraform_remote_state.networking.outputs.sts_endpoint_client_security_group.id,
   ]
 
   tags = { "Name" = "Nessus" }


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some security groups to the Nessus instance.

## 💭 Motivation and context ##

The Nessus instance requires these security groups to communicate with the VPC endpoints created in cisagov/cool-sharedservices-networking#71.

## 🧪 Testing ##

All automated tests pass.  These changes are identical to those in cisagov/cool-sharedservices-openvpn#61 and cisagov/cool-sharedservices-freeipa#63.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.